### PR TITLE
Add flows introduction page

### DIFF
--- a/4-flows/index.md
+++ b/4-flows/index.md
@@ -14,13 +14,15 @@ a simplified version of _git-flow_ adapted to environments where releases are do
 too much frequently.
 
 Some flows proposed for our projects:
-<!--- We need to talk with the TLs in order to define them, and others --->
+<!-- We need to talk with the TLs in order to define them, and others -->
 
 * migration-to-git Flow (because it is also important to know how to enhance 
   this documentation)
 * Doppler Flow 
 * Lander Flow 
-* DCA Flow <!--- I am not sure to include the complete Project and Client name here --->
+* DCA Flow 
+
+<!-- About DCA, I am not sure to include the complete Project and Client name here -->
 
 
 


### PR DESCRIPTION
Hi @AlphaGit and @noeliasfranco,

In my opinion, since we have a lot of different projects with very different needs and internal workflows, the best way to deal with it is to propose the world wide most popular flows, and based on them, trying to determine with TLs help, the adaptations for their own projects. 

In this way, we can create a little library of examples that could be copied or adapted for other projects. Useful and flexible.

What do you think?

Right now writing a page describing a proposal for _DCA_ project (It is the project where I am working, I am not sure about to mention the real project name and client name here, what do you think?).
