### PR TITLE
Change gitattributes example to do not normalize all kind of files by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
+# Set default behaviour, in case users don't have core.autocrlf unset.
+* -text
 
 # These files are text and should be normalized (convert crlf =&gt; lf)
 *.cs      text diff=csharp

--- a/3-working-with-git/examples/.gitattributes
+++ b/3-working-with-git/examples/.gitattributes
@@ -1,5 +1,5 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
+# Set default behaviour, in case users don't have core.autocrlf unset.
+* -text
 
 # These files are text and should be normalized (convert crlf =&gt; lf)
 *.cs      text diff=csharp

--- a/3-working-with-git/gitconfig-file.md
+++ b/3-working-with-git/gitconfig-file.md
@@ -11,6 +11,9 @@ Only an advertisement, in order to avoid line endings conversion problems we rec
 
     [core]
 	autocrlf = false
+    safecrlf = false
+
+The property `safecrlf = false` is to avoid warning errors converting line endings in the files that we choose to convert automatically.
 
 See more information in [dealing with line endings](/migration-to-git/3-working-with-git/dealing-with-line-endings.html) 
 

--- a/3-working-with-git/repo-boilerplate.md
+++ b/3-working-with-git/repo-boilerplate.md
@@ -35,6 +35,8 @@ And push it to our GitHub repository `(6)` (see [push to a remote repo]).
 
 Congrats! Your repo is done to add your project files.
 
+It is not related to repository preparation, but at this point it could also be useful to take a look at our recommendations on [.gitconfig-file].
+
 
 
 [clone a remote repo]: /migration-to-git/3-working-with-git/clone-remote-repo.html
@@ -42,3 +44,4 @@ Congrats! Your repo is done to add your project files.
 [our default gitattributes]: https://github.com/MakingSense/migration-to-git/tree/gh-pages/3-working-with-git/examples/.gitattributes
 [commit changes]: /migration-to-git/3-working-with-git/commit-changes.html
 [push to a remote repo]: /migration-to-git/3-working-with-git/push-to-a-remote-repo.html
+[.gitconfig-file]: /migration-to-git/3-working-with-git/gitconfig-file.html


### PR DESCRIPTION
Also update gitconfig-file example in order to remove unwanted warning on the
normalized files.

Hi all, I am proposing this changes based on my experience on documentation repository. The idea is by default do not normalize line endings, only in specific extensions. Then, on these specific cases does not show a warning when the normalization is being applied.
