### PR TITLE
Remove `merge=union` in .gitattributes example

### DIFF
--- a/migration-to-git/3-working-with-git/examples/.gitattributes
+++ b/migration-to-git/3-working-with-git/examples/.gitattributes
@@ -37,14 +37,14 @@
 *.fsx     text
 *.hs      text
 
-*.csproj  text=auto merge=union 
-*.vbproj  text=auto merge=union 
-*.fsproj  text=auto merge=union 
-*.dbproj  text=auto merge=union 
+*.csproj  text=auto
+*.vbproj  text=auto
+*.fsproj  text=auto
+*.dbproj  text=auto
 
 
 # Declare files that will always have CRLF line endings on checkout.
-*.sln     text=auto eol=crlf merge=union 
+*.sln     text=auto eol=crlf
 
 # Images should be treated as binary
 # (binary is a macro for -text -diff)


### PR DESCRIPTION
It fix #42. I am merging without approvals because it seems that we all agree on it. 
