### PR TITLE
Use remotes references in checkouts

### DIFF
--- a/migration-to-git/4-flows/dp-flow.md
+++ b/migration-to-git/4-flows/dp-flow.md
@@ -155,8 +155,8 @@ Sprint `N` starts. In the planning we choose a lot of nice features to implement
         $ git tfs rcheckin -i integration
         $ git push upstream integration:integration
         $ git checkout -B develop tfs/default
-        $ git tfs rcheckin -i develop
         $ git merge --no-ff tfs/integration
+        $ git tfs rcheckin -i default
         $ git push upstream develop:develop
         ```
 


### PR DESCRIPTION
Hi @Gkolocsar, @gastonmancini, @matiasbeckerle and @jfazzini,

Since now `ffetch` do not maintains local branches anymore (see [git-helpers PR](https://github.com/MakingSense/git-helpers/pull/2)), we need to reference TFS branches explicitly.

Could you validate my changes in documentation?
